### PR TITLE
Colorization on Windows using colorama

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 2.0.1 *(2015-09-15)*
+----------------------------
+ * New: Fix colors on Windows. Use options `-f` / `--force-windows-colors` to force conversion
+   in case a terminal appears to be a tty. Requires module `colorama`
+
 Version 2.0.0 *(2015-05-25)*
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Make sure that `adb` from the [Android SDK][3] is on your PATH. This script will
 not work unless this is that case. That means, when you type `adb` and press
 enter into your terminal something actually happens.
 
+On Windows, you can do `pip install colorama` if you see weird arrows instead of
+colors. In case that does not help, try using option `-f`.
+
 To include `adb` and other android tools on your path:
 
     export PATH=$PATH:<path to Android SDK>/platform-tools

--- a/pidcat.py
+++ b/pidcat.py
@@ -27,7 +27,7 @@ import re
 import subprocess
 from subprocess import PIPE
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 LOG_LEVELS = 'VDIWEF'
 LOG_LEVELS_MAP = dict([(LOG_LEVELS[i], i) for i in range(len(LOG_LEVELS))])
@@ -46,6 +46,7 @@ parser.add_argument('-t', '--tag', dest='tag', action='append', help='Filter out
 parser.add_argument('-i', '--ignore-tag', dest='ignored_tag', action='append', help='Filter output by ignoring specified tag(s)')
 parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__, help='Print the version number and exit')
 parser.add_argument('-a', '--all', dest='all', action='store_true', default=False, help='Print all log messages')
+parser.add_argument('-f', '--force-windows-colors', dest='force_windows_colors', action='store_true', default=False, help='Force converting colors to Windows format')
 
 args = parser.parse_args()
 min_level = LOG_LEVELS_MAP[args.min_level.upper()]
@@ -85,6 +86,13 @@ try:
   h, width = struct.unpack('hh', fcntl.ioctl(0, termios.TIOCGWINSZ, struct.pack('hh', 0, 0)))
 except:
   pass
+
+try:
+  import colorama
+  colorama.init(convert=args.force_windows_colors)
+except ImportError:
+  if args.force_windows_colors:
+    raise
 
 BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
 


### PR DESCRIPTION
Added option -f/-force-windows-colors to force colorization if terminal
is tty but actually expects windows colors
